### PR TITLE
fix: Corrige o redirecionamento equivocado devido ao antigo domínio

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-gaviao.me

--- a/index.html
+++ b/index.html
@@ -118,12 +118,14 @@
       <div class="container">
 
         <div class="row">
+          <!-- Oculta o link para o Facebook temporiamente
           <div class="col-lg-4 col-md-6 text-center">
             <div class="service-box mt-5 mx-auto">
               <a href="https://www.facebook.com/vitor.gav1ao" target="_blank"><i class="fa fa-4x fa-facebook text-primary mb-3 sr-icons"></i></a>
               <h3 class="mb-3">Facebook</h3>
             </div>
           </div>
+          -->
           
           <div class="col-lg-4 col-md-6 text-center">
             <div class="service-box mt-5 mx-auto">


### PR DESCRIPTION
- Devido ao antigo domínio `gaviao.me`, estava ocorrendo um redirecionamento equivocado no site;
- Remove temporariamente o atalho para o Facebook;